### PR TITLE
added target parameter

### DIFF
--- a/models/_generate_layers.py
+++ b/models/_generate_layers.py
@@ -22,7 +22,6 @@ from returnn.tf.layers.basic import ConstantLayer, VariableLayer, CondLayer, Swi
 from returnn.tf.layers.rec import RecLayer, RnnCellLayer, MaskedComputationLayer
 from returnn.tf.layers.rec import PositionalEncodingLayer, RelativePositionalEncodingLayer
 from returnn.tf.layers.rec import BaseChoiceLayer
-from returnn_common.models.base import LayerRef
 _my_dir = os.path.dirname(os.path.abspath(__file__))
 _out_filename = f"{_my_dir}/_generated_layers.py"
 

--- a/models/_generate_layers.py
+++ b/models/_generate_layers.py
@@ -272,7 +272,7 @@ class LayerSignature:
         inspect.Parameter(
           name="target",
           kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        param_type_s=LayerRef,
+        param_type_s="LayerRef",
         docstring="explicit target")
     for name, param in self.inspect_init_sig.parameters.items():
       # Ignore a number of params which are handled explicitly.

--- a/models/_generate_layers.py
+++ b/models/_generate_layers.py
@@ -271,7 +271,7 @@ class LayerSignature:
         self,
         inspect.Parameter(
           name="target",
-          kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
+          kind=inspect.Parameter.KEYWORD_ONLY),
         param_type_s="LayerRef",
         docstring="explicit target")
     for name, param in self.inspect_init_sig.parameters.items():

--- a/models/_generate_layers.py
+++ b/models/_generate_layers.py
@@ -253,7 +253,7 @@ class LayerSignature:
     LinearLayer, ConvLayer, TransposedConvLayer, RecLayer, RnnCellLayer,
     PositionalEncodingLayer, RelativePositionalEncodingLayer}
 
-  _LayerClassesWithExplicitTarget={
+  _LayerClassesWithExplicitTarget = {
     BaseChoiceLayer}
 
   def _init_args(self):

--- a/models/_generate_layers.py
+++ b/models/_generate_layers.py
@@ -21,7 +21,8 @@ from returnn.tf.layers.basic import LinearLayer, ConvLayer, TransposedConvLayer
 from returnn.tf.layers.basic import ConstantLayer, VariableLayer, CondLayer, SwitchLayer, SubnetworkLayer
 from returnn.tf.layers.rec import RecLayer, RnnCellLayer, MaskedComputationLayer
 from returnn.tf.layers.rec import PositionalEncodingLayer, RelativePositionalEncodingLayer
-
+from returnn.tf.layers.rec import BaseChoiceLayer
+from returnn_common.models.base import LayerRef
 _my_dir = os.path.dirname(os.path.abspath(__file__))
 _out_filename = f"{_my_dir}/_generated_layers.py"
 
@@ -253,6 +254,9 @@ class LayerSignature:
     LinearLayer, ConvLayer, TransposedConvLayer, RecLayer, RnnCellLayer,
     PositionalEncodingLayer, RelativePositionalEncodingLayer}
 
+  _LayerClassesWithExplicitTarget={
+    BaseChoiceLayer}
+
   def _init_args(self):
     # n_out is handled specially
     if self.layer_class in self._LayerClassesWithExplicitDim:
@@ -263,6 +267,14 @@ class LayerSignature:
           kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
         param_type_s="int",
         docstring="output dimension")
+    if self.layer_class in self._LayerClassesWithExplicitTarget:
+      self.params["target"] = LayerSignature.Param(
+        self,
+        inspect.Parameter(
+          name="target",
+          kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        param_type_s=LayerRef,
+        docstring="explicit target")
     for name, param in self.inspect_init_sig.parameters.items():
       # Ignore a number of params which are handled explicitly.
       if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):


### PR DESCRIPTION
This adds the target parameter to Layers in which explicitly setting the parameter is required. For now this is just the `BaseChoice` Layer. Not all layers should have the possibility to set targets, since it does not make sense in most cases. Thats why the same logic as for `n_out` is used.