### PR TITLE
Exclude __class__ from extra_opts

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -285,7 +285,7 @@ class Rec(ISubnet):
     super(Rec, self).__init__()
     self.extra_opts = {
       key: value for (key, value) in locals().items()
-      if value is not NotSpecified and key != "self"}
+      if value is not NotSpecified and key != "self" and key != "__class__"}
 
   def step(self, *args, **kwargs) -> LayerRef:
     """

--- a/models/base.py
+++ b/models/base.py
@@ -285,7 +285,7 @@ class Rec(ISubnet):
     super(Rec, self).__init__()
     self.extra_opts = {
       key: value for (key, value) in locals().items()
-      if value is not NotSpecified and key != "self" and key != "__class__"}
+      if value is not NotSpecified and key not in {"self", "__class__"}}
 
   def step(self, *args, **kwargs) -> LayerRef:
     """


### PR DESCRIPTION
This PR adds the check wether the param for extra opts is `__class_` which otherwise would cause it to be written into the dictionary like `'__class__': <class 'returnn_common.models.base.Rec'>` 