### PR TITLE
Fix random Parameter init outside name ctx

### DIFF
--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -36,6 +36,28 @@ def test_simple_net_linear():
   dummy_run_net(config)
 
 
+def test_simple_net_linear_non_lazy():
+  class _Net(nn.Module):
+    def __init__(self):
+      super().__init__()
+      out_dim1 = nn.FeatureDim("linear1-out", 7)
+      out_dim2 = nn.FeatureDim("linear2-out", 13)
+      self.linear1 = nn.Linear(out_dim1)
+      self.linear2 = nn.Linear(out_dim2, in_dim=out_dim1)
+
+    @nn.scoped
+    def __call__(self, x) -> nn.Tensor:
+      """
+      Forward
+      """
+      x = self.linear1(x)
+      x = self.linear2(x)
+      return x
+
+  config, net_dict = dummy_config_net_dict(_Net())
+  dummy_run_net(config)
+
+
 def test_simple_net_linear_square_matrix():
   # https://github.com/rwth-i6/returnn_common/issues/17
   # https://github.com/rwth-i6/returnn/pull/871


### PR DESCRIPTION
Fix #109.

Fix non-lazy init of Linear.

Currently only the corresponding test case.

Or maybe we want to disallow this? Or lazily assign the parent name ctx land the name itself later, similar as we do for `Parameter`?
