### PR TITLE
Update gammatone net dict

### DIFF
--- a/asr/gt.py
+++ b/asr/gt.py
@@ -9,6 +9,7 @@ Code by Peter Vieting, and adopted.
 import tensorflow as tf
 import numpy
 from returnn.tf.network import TFNetwork, ExternData
+from returnn.tf.util.data import FeatureDim
 
 tf1 = tf.compat.v1
 
@@ -64,39 +65,73 @@ def make_returnn_audio_features_func():
   return _extract
 
 
-def get_net_dict(num_channels=50):
+def get_net_dict(
+    num_channels=50, sample_rate=16000, gt_filterbank_size=640, temporal_integration_size=400,
+    temporal_integration_strides=160, normalization="batch", freq_max=7500., source="data",
+):
   """
-  Get net dict
+  :param int num_channels: gammatone feature output dimension
+  :param int|float sample_rate: sampling rate of input waveform
+  :param int gt_filterbank_size: size of gammatone filterbank (in samples)
+  :param int temporal_integration_size: size of filter for temporal integration
+  :param int temporal_integration_strides: strides of filter for temporal integration
+  :param str|None normalization: batch, time or None
+  :param float freq_max: maximum frequency of Gammatone filterbank
+  :param str source: source layer name
   """
-  return {
-    'shift_0': {'class': 'slice', 'axis': 'T', 'slice_end': -1},
-    'shift_1_raw': {'class': 'slice', 'axis': 'T', 'slice_start': 1},
+  gammatone_feature_dim = FeatureDim("gammatone_feature_dim", num_channels)
+  gammatone_split_dummy_dim = FeatureDim("gammatone_split_dummy_dim", 1)
+  net_dict = {
+    'shift_0': {'class': 'slice', 'axis': 'T', 'slice_end': -1, 'from': source},
+    'shift_1_raw': {'class': 'slice', 'axis': 'T', 'slice_start': 1, 'from': source},
     'shift_1': {'class': 'reinterpret_data', 'from': 'shift_1_raw', 'set_axes': {'T': 'time'}, 'size_base': 'shift_0'},
     'preemphasis': {'class': 'combine', 'from': ['shift_1', 'shift_0'], 'kind': 'sub'},
-    'gammatone_filterbank_padding': {'class': 'pad', 'axes': 'T', 'from': 'preemphasis', 'padding': (574, 0)},
     'gammatone_filterbank': {
       'class': 'conv',
       'activation': 'abs',
-      'filter_size': (640,),
+      'filter_size': (gt_filterbank_size,),
       'forward_weights_init': {
-        'class': 'GammatoneFilterbankInitializer', 'length': 0.04, 'num_channels': num_channels},
-      'from': 'gammatone_filterbank_padding',
+        'class': 'GammatoneFilterbankInitializer',
+        'num_channels': num_channels,
+        'length': gt_filterbank_size / sample_rate,
+        'sample_rate': sample_rate,
+        'freq_max': freq_max},
+      'from': 'preemphasis',
       'n_out': num_channels,
+      'in_spatial_dims': 'T',
       'padding': 'valid'},
-    'gammatone_filterbank_split': {'class': 'split_dims', 'axis': 'F', 'dims': (-1, 1), 'from': 'gammatone_filterbank'},
+    'gammatone_filterbank_split': {
+      'class': 'split_dims',
+      'axis': 'F',
+      'dims': (gammatone_feature_dim, gammatone_split_dummy_dim),
+      'from': 'gammatone_filterbank'},
     'temporal_integration': {
       'class': 'conv',
-      'filter_size': (400, 1),
-      'forward_weights_init': 'numpy.hanning(400).reshape((400, 1, 1, 1))',
+      'filter_size': (temporal_integration_size, 1),
+      'forward_weights_init': 'numpy.hanning({}).reshape(({}, 1, 1, 1))'.format(
+        temporal_integration_size, temporal_integration_size),
       'from': 'gammatone_filterbank_split',
       'n_out': 1,
       'padding': 'valid',
-      'strides': (160, 1)},
-    'temporal_integration_merge': {'class': 'merge_dims', 'axes': 'except_time', 'from': 'temporal_integration'},
+      'strides': (temporal_integration_strides, 1),
+      'in_spatial_dims': ["T", gammatone_feature_dim],
+      'out_dim': gammatone_split_dummy_dim},
+    'temporal_integration_merge': {
+      'class': 'merge_dims',
+      'axes': [gammatone_feature_dim, gammatone_split_dummy_dim],
+      'from': 'temporal_integration'},
     'compression': {
       'class': 'eval',
       'eval': 'tf.pow(source(0) + 1e-06, 0.1)',
       'from': 'temporal_integration_merge'},
     'dct': {'class': 'dct', 'from': 'compression'},
-    'output': {'class': 'batch_norm', 'from': 'dct'},
   }
+  if normalization is None:
+    net_dict['output'] = {'class': 'copy', 'from': 'dct'}
+  elif normalization == 'batch':
+    net_dict['output'] = {'class': 'batch_norm', 'from': 'dct'}
+  elif normalization == 'time':
+    net_dict['output'] = {'class': 'norm', 'axes': 'T', 'from': 'dct'}
+  else:
+    raise NotImplementedError
+  return net_dict


### PR DESCRIPTION
Some updates to allow setting parameters when creating the Gammatone net dict.

The default network is changed by this. I'm not sure if anyone is using this, if yes should we use `BehaviorVersion` here?

The changes are for default behavior are
- removing `'gammatone_filterbank_padding'` which doesn't belong here from my point of view (this was taken from one of my configs but it's too specific here)
- using dim tags for split and merge
- setting `'in_spatial_dims'` and `'out_dim'` for convolutions
- adding `"from"` where it was missing

I could also change `'` -> `"` because that's used mostly in RETURNN, but didn't want to make the diff too complicated initially.