### PR TITLE
Kullback-Leibler divergence

### DIFF
--- a/nn/loss.py
+++ b/nn/loss.py
@@ -101,7 +101,6 @@ def kl_div(*, target: nn.Tensor, target_type: str,
   # Using nn.exp(log_target) instead of target (but not nn.safe_exp!)
   # to avoid calculating softmax twice (efficiency)
   # (because nn.safe_log(target) = log_softmax(...), so a separate softmax calculation).
-  log_target = nn.safe_log(target)
   kl = nn.dot(nn.exp(log_target), log_target - log_est, reduce=axis)
 
   return kl

--- a/nn/loss.py
+++ b/nn/loss.py
@@ -55,3 +55,20 @@ def cross_entropy(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: st
   else:
     raise ValueError("estimated_kind must be 'probs', 'log-probs' or 'logits'")
   return -nn.dot(target, log_prob, reduce=axis)
+
+
+def kl_div(*, target: nn.Tensor, estimated: nn.Tensor):
+  """
+  Kullback-Leibler divergence (https://en.wikipedia.org/wiki/Kullback-Leibler_divergence)
+
+  L(target, estimated) = target * log(target / estimated)
+                       = target * (log(target) - log(estimated)
+  :param target: target probabilities
+  :param estimated: estimated probabilities
+  :return: KL-div
+  """
+  log_target = nn.log(target)
+  log_est = nn.log(estimated)
+  kl = target * (log_target - log_est)
+
+  return kl

--- a/nn/loss.py
+++ b/nn/loss.py
@@ -57,13 +57,17 @@ def cross_entropy(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: st
   return -nn.dot(target, log_prob, reduce=axis)
 
 
-def kl_div(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: str, axis: Optional[nn.Dim] = None) -> nn.Tensor:
+def kl_div(*, target: nn.Tensor, target_type: str,
+           estimated: nn.Tensor, estimated_type: str,
+           axis: Optional[nn.Dim] = None) -> nn.Tensor:
   """
   Kullback-Leibler divergence (https://en.wikipedia.org/wiki/Kullback-Leibler_divergence)
 
   L(target, estimated) = target * log(target / estimated)
                        = target * (log(target) - log(estimated)
+
   :param target: probs, normalized. can also be sparse
+  :param target_type: "probs", "log-probs" or "logits"
   :param estimated: probs, log-probs or logits, specified via ``estimated_type``
   :param estimated_type: "probs", "log-probs" or "logits"
   :param axis: the axis to reduce over
@@ -72,6 +76,17 @@ def kl_div(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: str, axis
   if not axis:
     assert target.feature_dim
     axis = target.feature_dim
+
+  if target.data.sparse:
+    raise NotImplementedError(f"Sparse target {target} not supported for KL. Use cross entropy instead?")
+  if target_type == "probs":
+    log_target = nn.safe_log(target)
+  elif estimated_type == "log-probs":
+    log_target = target
+  elif estimated_type == "logits":
+    log_target = nn.log_softmax(target, axis=axis)
+  else:
+    raise ValueError("target_kind must be 'probs', 'log-probs' or 'logits'")
 
   if estimated_type == "probs":
     log_est = nn.safe_log(estimated)
@@ -82,7 +97,11 @@ def kl_div(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: str, axis
   else:
     raise ValueError("estimated_kind must be 'probs', 'log-probs' or 'logits'")
 
+  # Assuming target = softmax(...):
+  # Using nn.exp(log_target) instead of target (but not nn.safe_exp!)
+  # to avoid calculating softmax twice (efficiency)
+  # (because nn.safe_log(target) = log_softmax(...), so a separate softmax calculation).
   log_target = nn.safe_log(target)
-  kl = target * (log_target - log_est)
+  kl = nn.dot(nn.exp(log_target), log_target - log_est, reduce=axis)
 
   return kl


### PR DESCRIPTION
This is a draft for the Kullback-Leibler divergence (loss).

The idea is to use this with `.mark_as_loss()`. This is only a draft since I am not 100% sure about all the modalities, which might need to be taken care of (or are already dealt with with the marking)

In my mind this is: 
- conversion to actual (batch-wise) loss
- potential inconsistencies / stability concerns with the input e.g. PyTorch (https://pytorch.org/docs/stable/generated/torch.nn.KLDivLoss.html) assumes `estimated` to be in the log-space already and makes it optional for `target` to be too. Do we want to enforce/handle this in the same way? 