### PR TITLE
Normalize

### DIFF
--- a/nn/math_.py
+++ b/nn/math_.py
@@ -317,9 +317,9 @@ def cumsum(
   return layer
 
 
-def layer_norm(a: nn.Tensor, *, axes: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
+def normalize(a: nn.Tensor, *, axes: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
   """
-  Calculates layer norm for given layer, based on the input dims
+  Calculates normalization for given layer, based on the input dims
   :param a: input
   :param axes: axes over which the mean and variance are computed
   :param epsilon: epsilon for numerical stability

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -317,9 +317,10 @@ def cumsum(
   return layer
 
 
-def normalize(a: nn.Tensor, *, axes: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
+def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
   """
   Calculates normalization for given layer, based on the input dims
+  
   :param a: input
   :param axes: axes over which the mean and variance are computed
   :param epsilon: epsilon for numerical stability

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -315,3 +315,16 @@ def cumsum(
     name=name)
   del state
   return layer
+
+
+def layer_norm(a: nn.Tensor, *, axes: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
+  """
+  Calculates layer norm for given layer, based on the input dims
+  :param a: input
+  :param axes: axes over which the mean and variance are computed
+  :param epsilon: epsilon for numerical stability
+  """
+
+  mean = nn.reduce(a, axis=axes, mode='mean')
+  variance = nn.reduce((a - mean) ** 2, mode='mean', axis=axes, name='variance')
+  return (a - mean) * nn.rsqrt(variance + epsilon)

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -324,6 +324,7 @@ def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: f
   :param a: input
   :param axes: axes over which the mean and variance are computed
   :param epsilon: epsilon for numerical stability
+  :return: (a - mean) / sqrt(variance + epsilon)
   """
 
   mean, variance = nn.moments(a, axis=axis)

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -325,6 +325,5 @@ def normalize(a: nn.Tensor, *, axes: Union[nn.Dim, Sequence[nn.Dim]], epsilon: f
   :param epsilon: epsilon for numerical stability
   """
 
-  mean = nn.reduce(a, axis=axes, mode='mean')
-  variance = nn.reduce((a - mean) ** 2, mode='mean', axis=axes, name='variance')
+  mean, variance = nn.moments(a, axis=axis)
   return (a - mean) * nn.rsqrt(variance + epsilon)

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -322,7 +322,7 @@ def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: f
   Calculates normalization for given layer, based on the input dims
   
   :param a: input
-  :param axes: axes over which the mean and variance are computed
+  :param axis: axis over which the mean and variance are computed
   :param epsilon: epsilon for numerical stability
   :return: (a - mean) / sqrt(variance + epsilon)
   """

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -320,7 +320,7 @@ def cumsum(
 def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6) -> nn.Tensor:
   """
   Calculates normalization for given layer, based on the input dims
-  
+
   :param a: input
   :param axis: axis over which the mean and variance are computed
   :param epsilon: epsilon for numerical stability

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -317,7 +317,7 @@ def cumsum(
   return layer
 
 
-def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6):
+def normalize(a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]], epsilon: float = 1e-6) -> nn.Tensor:
   """
   Calculates normalization for given layer, based on the input dims
   


### PR DESCRIPTION
Implementation for #142 

Pretty much just replicating the math part of the `NormLayer` from returnn.

I think we should not do scale and bias here (can be done explicitly be the user afterwards).

I am unsure about the `keepdims=True` of the reduces in returnn, is there similar handling required here too? I dont think `reduce` offers this option, but I am not sure, do we even need this? 