### PR TITLE
add ref_extern_data_dims_via_global_config flag

### DIFF
--- a/nn/naming.py
+++ b/nn/naming.py
@@ -718,8 +718,9 @@ class ReturnnConfigSerializer:
       code_lines.append(import_str + "\n")
 
     if ref_extern_data_dims_via_global_config:
-      code_lines += ["from returnn.config import get_global_config\n",
-                     "config = get_global_config()\n"]
+      code_lines += [
+        "from returnn.config import get_global_config\n",
+        "config = get_global_config()\n"]
       for value in self._base_extern_data_dim_refs:
         code_lines += [f"{value.py_id_name()} = config.typed_dict[{value.py_id_name()!r}]\n"]
 

--- a/nn/naming.py
+++ b/nn/naming.py
@@ -722,7 +722,7 @@ class ReturnnConfigSerializer:
         "from returnn.config import get_global_config\n",
         "config = get_global_config()\n"]
       for value in self._base_extern_data_dim_refs:
-        code_lines += [f"{value.py_id_name()} = config.typed_dict[{value.py_id_name()!r}]\n"]
+        code_lines.append(f"{value.py_id_name()} = config.typed_dict[{value.py_id_name()!r}]\n")
 
     code_lines += [
       f"{dim_tags_proxy.py_code_str(exclude_dims=self._base_extern_data_dim_refs)}\n",


### PR DESCRIPTION
I changed `self._base_extern_data_dim_refs` from `set` to `list` because otherwise I would get undefined behavior. Maybe I overlooked something but this is how it worked for me now.