### PR TITLE
Remove nn.scoped

### DIFF
--- a/asr/gt.py
+++ b/asr/gt.py
@@ -56,7 +56,6 @@ class GammatoneV2(nn.Module):
       .reshape((temporal_integration_size, 1, 1))
       .astype(numpy.float32))
 
-  @nn.scoped
   def __call__(
         self,
         raw_samples: nn.Tensor,

--- a/asr/specaugment.py
+++ b/asr/specaugment.py
@@ -7,7 +7,6 @@ from typing import Union, Collection
 from .. import nn
 
 
-@nn.scoped
 def specaugment_v2(x: nn.Tensor, *,
                    spatial_dim: nn.Dim,
                    feature_dim: nn.Dim = nn.NotSpecified,
@@ -45,7 +44,6 @@ def specaugment_v2(x: nn.Tensor, *,
   return cond.result
 
 
-@nn.scoped
 def random_mask_v2(x: nn.Tensor, *,
                    mask_axis: nn.Dim,
                    broadcast_axis: Union[nn.Dim, Collection[nn.Dim]],
@@ -102,7 +100,6 @@ def random_mask_v2(x: nn.Tensor, *,
   return x
 
 
-@nn.scoped
 def _mask_v2(x: nn.Tensor, *,
              mask_axis: nn.Dim,
              pos: nn.Tensor,

--- a/asr/specaugment.py
+++ b/asr/specaugment.py
@@ -30,13 +30,15 @@ def specaugment_v2(x: nn.Tensor, *,
   with nn.Cond(nn.train_flag() | (not only_on_train)) as cond:
     x_masked = x
     spatial_len = nn.dim_value(x, axis=spatial_dim)
+    # time mask
     x_masked = random_mask_v2(
-      x_masked, mask_axis=spatial_dim, broadcast_axis=feature_dim, name="time_masking",
+      x_masked, mask_axis=spatial_dim, broadcast_axis=feature_dim,
       min_num=nn.minimum(step1 + step2, spatial_len),
       max_num=nn.minimum(nn.maximum(spatial_len // 100, 2) * (1 + step1 + step2 * 2), spatial_len),
       max_dims=20 // time_factor)
+    # feature mask
     x_masked = random_mask_v2(
-      x_masked, mask_axis=feature_dim, broadcast_axis=spatial_dim, name="feature_masking",
+      x_masked, mask_axis=feature_dim, broadcast_axis=spatial_dim,
       min_num=step1 + step2, max_num=2 + step1 + step2 * 2,
       max_dims=feature_dim.dimension // 5)
     cond.true = x_masked

--- a/nn/array_.py
+++ b/nn/array_.py
@@ -7,7 +7,6 @@ from returnn.util.basic import NotSpecified
 from .. import nn
 
 
-@nn.scoped
 def dim_value(source: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
   """
   :return: like tf.shape(source)[axis], or specifically sum(nn.length(source, axis=axis))

--- a/nn/array_.py
+++ b/nn/array_.py
@@ -65,7 +65,9 @@ def concat(*sources: Tuple[nn.Tensor, nn.Dim],
   opts = {}
   if allow_broadcast:
     opts["allow_broadcast"] = True
-  return nn.make_layer({"class": "concat", "from": sources, **opts}, name=name or "concat")
+  return nn.make_layer(
+    {"class": "concat", "from": sources, **opts},
+    name=name or "concat", name_ctx_ignore_top_stack_frames=1)
 
 
 def cum_concat_step(
@@ -76,6 +78,7 @@ def cum_concat_step(
   Concatenates all previous frames of a time-axis.
   See RETURNN :class:`CumConcatLayer` for details.
   """
+  nn.auto_setup_name_ctx_ignore_func(cum_concat_step)
   from ._generated_layers import rec_cum_concat
   return rec_cum_concat(
     source=source, axis=nn.single_step_dim,
@@ -115,6 +118,7 @@ def window(
   """
   Window. See :func:`rec_window`.
   """
+  nn.auto_setup_name_ctx_ignore_func(window)
   from ._generated_layers import rec_window
   layer, (window_dim, out_spatial_dim), state = rec_window(
     source,
@@ -133,6 +137,7 @@ def window_step(
   Window into the past when iterating.
   See :func:`rec_window`.
   """
+  nn.auto_setup_name_ctx_ignore_func(window_step)
   from ._generated_layers import rec_window
   out, _, state = rec_window(
     source, state=state,

--- a/nn/attention.py
+++ b/nn/attention.py
@@ -23,7 +23,6 @@ class AttentionFunc(Protocol):
                key_dim: nn.Dim, axis: nn.Dim, att_dropout: float = 0.1): ...
 
 
-@nn.scoped
 def dot_attention(query: nn.Tensor, keys: nn.Tensor, values: nn.Tensor, *,
                   key_dim: nn.Dim, axis: nn.Dim, att_dropout: float = 0.1) -> nn.Tensor:
   """
@@ -74,7 +73,6 @@ class GenericSelfAttention(nn.Module):
       k_accum=nn.LayerState(nn.zeros([nn.batch_dim, expand_dim, self.num_heads, self.key_dim_per_head])),
       v_accum=nn.LayerState(nn.zeros([nn.batch_dim, expand_dim, self.num_heads, self.value_dim_per_head])))
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *, axis: nn.Dim,
                causal: Optional[bool] = None, state: Optional[nn.LayerState] = None
                ) -> Tuple[nn.Tensor, Optional[nn.LayerState]]:
@@ -116,10 +114,10 @@ class SelfAttention(GenericSelfAttention):
   """
   Classic self attention on sequence level
   """
-  @nn.scoped
-  def __call__(self, source: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
+  def __call__(self, source: nn.Tensor, *, axis: nn.Dim, **_kwargs) -> nn.Tensor:
     """forward"""
-    out, _ = super().__call__(source, axis=axis, causal=False, name="")
+    assert not _kwargs
+    out, _ = super().__call__(source, axis=axis, causal=False)
     return out
 
 
@@ -127,9 +125,9 @@ class CausalSelfAttention(GenericSelfAttention):
   """
   Classic causal self attention
   """
-  @nn.scoped
-  def __call__(self, source: nn.Tensor, *, axis: nn.Dim, state: Optional[nn.LayerState] = None
+  def __call__(self, source: nn.Tensor, *, axis: nn.Dim, state: Optional[nn.LayerState] = None, **_kwargs
                ) -> Tuple[nn.Tensor, nn.LayerState]:
     """forward"""
-    out, state = super().__call__(source, causal=True, axis=axis, state=state, name="")
+    assert not _kwargs
+    out, state = super().__call__(source, causal=True, axis=axis, state=state)
     return out, state

--- a/nn/base.py
+++ b/nn/base.py
@@ -30,7 +30,6 @@ Code example::
         super().__init__()
         self.lstm = nn.LSTM(nn.FeatureDim("lstm-out", 1024))
 
-      @nn.scoped
       def __call__(self, x: nn.Tensor) -> nn.Tensor:
         y = self.lstm(x)
         return y
@@ -721,7 +720,7 @@ def make_layer(layer_dict: LayerDictRaw, *,
   :param Data|None predefined_out_data: normally we can derive the out data automatically.
     If this should be skipped, you can pass this explicitly.
   """
-  if isinstance(name, str):
+  if isinstance(name, str) or not name:
     name_ctx = nn.NameCtx(suggested_name=name)
     created_name_ctx = True
   elif isinstance(name, nn.NameCtx):

--- a/nn/base.py
+++ b/nn/base.py
@@ -700,6 +700,7 @@ class LayerState(dict):
 def make_layer(layer_dict: LayerDictRaw, *,
                name: Optional[Union[str, nn.NameCtx]] = None,
                predefined_out_data: Optional[Data] = None,
+               name_ctx_ignore_top_stack_frames: int = 0,
                ) -> Tensor:
   """
   Creates the layer. This also registers the layer instance in the top name ctx.
@@ -719,9 +720,17 @@ def make_layer(layer_dict: LayerDictRaw, *,
     if NameCtx, will use this.
   :param Data|None predefined_out_data: normally we can derive the out data automatically.
     If this should be skipped, you can pass this explicitly.
+  :param int name_ctx_ignore_top_stack_frames: for :func:`NameCtx.current_ctx`.
+    If your calling function creates exactly one single layer, you might want to ignore its stack frame
+    and set ignore_top_stack_frames=1 and also set a name for the layer.
+    If you are potentially creating multiple layers in your calling function,
+    leave the default ignore_top_stack_frames=0.
+    Some postprocessing step might anyway simplify obsolete subnetworks,
+    see :mod:`naming`.
   """
   if isinstance(name, str) or not name:
-    name_ctx = nn.NameCtx(suggested_name=name)
+    parent_ctx = nn.NameCtx.current_ctx(ignore_top_stack_frames=name_ctx_ignore_top_stack_frames + 1)
+    name_ctx = nn.NameCtx(suggested_name=name, parent=parent_ctx)
     created_name_ctx = True
   elif isinstance(name, nn.NameCtx):
     name_ctx = name

--- a/nn/conformer.py
+++ b/nn/conformer.py
@@ -30,7 +30,6 @@ class ConformerPositionwiseFeedForward(nn.Module):
     self.linear_ff = nn.Linear(ff_dim)
     self.linear_out = nn.Linear(out_dim)
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor) -> nn.Tensor:
     """forward"""
     x_ff1 = self.linear_ff(inp)
@@ -60,7 +59,6 @@ class ConformerConvBlock(nn.Module):
     self.positionwise_conv2 = nn.Linear(out_dim)
     self.norm = norm
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
     """forward"""
     x_conv1 = self.positionwise_conv1(inp)
@@ -102,7 +100,6 @@ class ConformerConvSubsample(nn.Module):
       self.conv_layers.append(
         nn.Conv2d(filter_size=filter_size, out_dim=out_dim, padding=padding))
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, in_spatial_dim: nn.Dim) -> Tuple[nn.Tensor, nn.Dim]:
     """forward"""
     in_spatial_dims = [in_spatial_dim, inp.feature_dim]
@@ -176,7 +173,6 @@ class ConformerEncoderLayer(nn.Module):
 
     self.final_layer_norm = nn.LayerNorm()
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
     """forward"""
     # FFN
@@ -254,7 +250,6 @@ class ConformerEncoder(nn.Module):
 
     self.layers = nn.Sequential(_copy.deepcopy(encoder_layer) for _ in range(num_layers))
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, in_spatial_dim: nn.Dim) -> Tuple[nn.Tensor, nn.Dim]:
     """forward"""
     x_subsample, out_spatial_dim = self.conv_subsample_layer(inp, in_spatial_dim=in_spatial_dim)

--- a/nn/container.py
+++ b/nn/container.py
@@ -72,7 +72,6 @@ class Sequential(ModuleList):
   """
   Sequential Module, takes callable of Modules which are then executed in sequence
   """
-  @nn.scoped
   def __call__(self, inp, **kwargs) -> nn.Tensor:
     """
     Forward

--- a/nn/conv.py
+++ b/nn/conv.py
@@ -117,7 +117,6 @@ class _Conv(_ConvOrTransposedConv):
     self.dilation_rate = dilation_rate
     self.groups = groups
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *,
                in_dim: Optional[nn.Dim] = None,
                in_spatial_dims: Sequence[nn.Dim]
@@ -238,7 +237,6 @@ class _TransposedConv(_ConvOrTransposedConv):
     self.remove_padding = remove_padding
     self.output_padding = output_padding
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *,
                in_dim: Optional[nn.Dim] = None,
                in_spatial_dims: Sequence[nn.Dim]

--- a/nn/decoder/base.py
+++ b/nn/decoder/base.py
@@ -77,7 +77,6 @@ class Decoder(nn.Module):
     self.log_prob_separate_nb = log_prob_separate_nb
     self.log_prob_separate_wb = log_prob_separate_wb
 
-  @nn.scoped
   def __call__(self, encoder: nn.Tensor) -> nn.Tensor:
     """
     Make one decoder step (train and/or recognition).
@@ -93,7 +92,6 @@ class IDecoderLabelSyncRnn(nn.Module):
   """
   Represents SlowRNN in Transducer.
   """
-  @nn.scoped
   def __call__(self, *,
                prev_sparse_label_nb: nn.Tensor,
                prev_emit: nn.Tensor,
@@ -114,7 +112,6 @@ class IDecoderStepSyncRnn(nn.Module):
   which is alignment-synchronous or time-synchronous for RNN-T/RNA/CTC,
   or label-synchronous for att-enc-dec.
   """
-  @nn.scoped
   def __call__(self, *,
                prev_label_wb: nn.Tensor,
                encoder: nn.Tensor,  # TODO enc ctx. or not? need full encoder for full-sum case...
@@ -145,7 +142,6 @@ class IDecoderLogProbSeparateWb(nn.Module):
   """
   Log prob with blank.
   """
-  @nn.scoped
   def __call__(self, step_sync_rnn: nn.Tensor, log_prob_nb: nn.Tensor) -> nn.Tensor:
     """
     Make layer dict.

--- a/nn/encoder/base.py
+++ b/nn/encoder/base.py
@@ -29,7 +29,6 @@ class IEncoder(nn.Module, ABC):
 
   out_dim: nn.Dim
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor) -> nn.Tensor:
     """
     Encode the input
@@ -45,7 +44,6 @@ class ISeqFramewiseEncoder(nn.Module, ABC):
 
   out_dim: nn.Dim
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *, spatial_dim: nn.Dim) -> nn.Tensor:
     raise NotImplementedError
 
@@ -67,6 +65,5 @@ class ISeqDownsamplingEncoder(nn.Module, ABC):
   # The downsampling factor only describes the linear factor in the limit.
   downsample_factor: Union[int, float]
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *, in_spatial_dim: nn.Dim) -> Tuple[nn.Tensor, nn.Dim]:
     raise NotImplementedError

--- a/nn/linear.py
+++ b/nn/linear.py
@@ -33,7 +33,6 @@ class Linear(nn.Module):
       self.bias.initial = 0.
     self.initialized = True
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *, in_dim: Optional[nn.Dim] = None) -> nn.Tensor:
     source = nn.check_in_feature_dim_lazy_init(source, in_dim, self.in_dim, self._lazy_init)
     out = nn.dot(source, self.weight, reduce=self.in_dim)

--- a/nn/loss.py
+++ b/nn/loss.py
@@ -20,7 +20,6 @@ from typing import Optional, Union
 from .. import nn
 
 
-@nn.scoped
 def cross_entropy(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: str,
                   axis: Optional[nn.Dim] = None) -> nn.Tensor:
   """
@@ -63,7 +62,6 @@ def cross_entropy(*, target: nn.Tensor, estimated: nn.Tensor, estimated_type: st
   return -nn.dot(target, log_prob, reduce=axis)
 
 
-@nn.scoped
 def binary_cross_entropy(*,
                          target: nn.Tensor,
                          pos_estimated: nn.Tensor, pos_estimated_type: str,
@@ -146,7 +144,6 @@ def binary_cross_entropy(*,
     )
 
 
-@nn.scoped
 def kl_div(*, target: nn.Tensor, target_type: str,
            estimated: nn.Tensor, estimated_type: str,
            axis: Optional[nn.Dim] = None) -> nn.Tensor:
@@ -196,7 +193,6 @@ def kl_div(*, target: nn.Tensor, target_type: str,
   return kl
 
 
-@nn.scoped
 def mean_absolute_difference(a: nn.Tensor, b: nn.Tensor, *, axis: Optional[nn.Dim] = None) -> nn.Tensor:
   """
   Mean absolute difference, mean absolute error (MAE), or L1 loss between two tensors,
@@ -208,7 +204,6 @@ def mean_absolute_difference(a: nn.Tensor, b: nn.Tensor, *, axis: Optional[nn.Di
   return nn.reduce(nn.abs(a - b), mode="mean", axis=axis)
 
 
-@nn.scoped
 def mean_squared_difference(a: nn.Tensor, b: nn.Tensor, *, axis: Optional[nn.Dim] = None) -> nn.Tensor:
   """
   Mean squared difference between two tensors,

--- a/nn/math_.py
+++ b/nn/math_.py
@@ -180,7 +180,6 @@ def minimum(a: Union[nn.Tensor, int, float], b: Union[nn.Tensor, int, float],
   return combine(a, b, kind="minimum", name=name or "minimum")
 
 
-@nn.scoped
 def gating(x: nn.Tensor, *, axis: Optional[nn.Dim] = None,
            gate_func=sigmoid, act_func=identity) -> nn.Tensor:
   """

--- a/nn/module.py
+++ b/nn/module.py
@@ -246,10 +246,15 @@ class Functional(Module):
   def get_default_name(self) -> str:
     """default name"""
     import re
-    m = re.match(r"^Tensor\.__(.*)__$", self.func.__qualname__)
-    if m:
-      return m.group(1)
-    return self.func.__qualname__
+    name = self.func.__qualname__
+    assert isinstance(name, str)
+    if name.startswith("Tensor.__"):
+      m = re.match(r"^Tensor\.__(.*)__$", name)
+      if m:
+        return m.group(1)
+    if ".<locals>." in name:
+      name = name.replace(".<locals>.", ".")
+    return name
 
   def __call__(self, *args, **kwargs):
     return self.func(*args, **kwargs)

--- a/nn/module.py
+++ b/nn/module.py
@@ -25,7 +25,6 @@ class Module:
           self.linear = nn.Linear(dim)
           self.activation = activation
 
-        @nn.scoped
         def __call__(self, x: nn.Tensor) -> nn.Tensor:
           x_ = x
           x = self.layer_norm(x)
@@ -120,7 +119,6 @@ class Module:
       name = camel_case_to_snake_case(name)
     return name
 
-  @nn.scoped
   def __call__(self, *args, **kwargs) -> Union[nn.Tensor, Tuple[nn.Tensor, nn.LayerState], Any]:
     raise NotImplementedError
 
@@ -253,7 +251,6 @@ class Functional(Module):
       return m.group(1)
     return self.func.__qualname__
 
-  @nn.scoped
   def __call__(self, *args, **kwargs):
     return self.func(*args, **kwargs)
 

--- a/nn/normalization.py
+++ b/nn/normalization.py
@@ -7,7 +7,6 @@ from typing import Optional, Sequence, Union, Tuple
 from .. import nn
 
 
-@nn.scoped
 def moments(x: nn.Tensor, axis: Union[nn.Dim, Sequence[nn.Dim]]) -> Tuple[nn.Tensor, nn.Tensor]:
   """
   :param x: input
@@ -54,7 +53,6 @@ class LayerNorm(nn.Module):
     self.bias.initial = 0.
     self.initialized = True
 
-  @nn.scoped
   def __call__(self, x: nn.Tensor, *, in_dim: Optional[nn.Dim] = None) -> nn.Tensor:
     x = nn.check_in_feature_dim_lazy_init(x, in_dim, self.in_dim, self._lazy_init)
     mean = nn.reduce(x, axis=self.in_dim, mode="mean")
@@ -142,7 +140,6 @@ class BatchNorm(nn.Module):
       self.beta.initial = 0.
     self.initialized = True
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *, in_dim: Optional[nn.Dim] = None) -> nn.Tensor:
     source = nn.check_in_feature_dim_lazy_init(source, in_dim, self.in_dim, self._lazy_init)
     # We wrap the RETURNN layer because we want efficient handling if possible,

--- a/nn/rand.py
+++ b/nn/rand.py
@@ -16,7 +16,6 @@ class Random(nn.Module):
 
   _state_dim = nn.FeatureDim("random-state", None)
 
-  @nn.scoped
   def __call__(self, **kwargs) -> nn.Tensor:
     # For every call, we create a new state var to make sure there is no non-determinism.
     # https://github.com/rwth-i6/returnn_common/issues/148

--- a/nn/rec.py
+++ b/nn/rec.py
@@ -45,7 +45,6 @@ class _Rec(nn.Module):
         param_.initial = nn.init.Glorot()
         setattr(self, f"param_{param}", param_)
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *,
                axis: nn.Dim,
                state: Optional[Union[nn.Tensor, Dict[str, nn.Tensor], nn.NotSpecified]] = nn.NotSpecified,

--- a/nn/transformer.py
+++ b/nn/transformer.py
@@ -46,7 +46,6 @@ class TransformerEncoderLayer(nn.Module):
     self.ff_norm = norm()
     self.dropout = dropout
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
     """
     Two possible forward variants of encoder, defined by self.norm_first.
@@ -97,7 +96,6 @@ class TransformerEncoder(nn.Module):
     self.num_layers = num_layers
     self.norm = norm(eps=norm_eps) if isinstance(norm, type) else norm
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
     """
     Applies every encoder layer initialized in self.layers.
@@ -152,7 +150,6 @@ class TransformerDecoderLayer(nn.Module):
     self.activation = ff_activation
     self.dropout = dropout
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *,
                axis: nn.Dim,
                memory: nn.Tensor,
@@ -221,7 +218,6 @@ class TransformerDecoder(nn.Module):
     self.num_layers = num_layers
     self.norm = norm(eps=norm_eps) if isinstance(norm, type) else norm
 
-  @nn.scoped
   def __call__(self, inp: nn.Tensor, *,
                axis: nn.Dim,
                memory: nn.Tensor,
@@ -362,7 +358,6 @@ class Transformer(nn.Module):
     self.norm = norm
     self.norm_eps = norm_eps
 
-  @nn.scoped
   def __call__(self, source: nn.Tensor, *,
                source_spatial_axis: nn.Dim,
                target: Optional[Union[nn.Tensor, nn.SearchFuncInterface]] = None,

--- a/nn/utils.py
+++ b/nn/utils.py
@@ -215,7 +215,6 @@ def range_for_dim(dim: nn.Dim, *, dim_source: Optional[nn.Tensor] = None, sparse
   return out
 
 
-@nn.scoped
 def sparse_to_dense(source: nn.Tensor, *,
                     label_value: Union[nn.Tensor, int, float],
                     other_value: Union[nn.Tensor, int, float]) -> nn.Tensor:
@@ -369,7 +368,6 @@ def gather_by_mask(x: nn.Tensor, *,
     "unit": {"class": "copy", "from": "data"}}, name=name), out_spatial_dim
 
 
-@nn.scoped
 def ctc_greedy_decode(logits: nn.Tensor, *,
                       in_spatial_dim: nn.Dim,
                       feature_dim: Optional[nn.Dim] = None,

--- a/nn/utils.py
+++ b/nn/utils.py
@@ -232,18 +232,17 @@ def sparse_to_dense(source: nn.Tensor, *,
   return nn.where(source == indices, label_value, other_value)
 
 
-def one_hot(source: nn.Tensor, *, name: Optional[str] = None) -> nn.Tensor:
+def one_hot(source: nn.Tensor) -> nn.Tensor:
   """
   one_hot. special case of :func:`sparse_to_dense`.
 
   Note that usually this is not needed as most other functions should handle sparse tensors just fine
   and much more efficiently than they would be with dense tensors.
   """
-  return sparse_to_dense(source, label_value=1., other_value=0., name=name or "one_hot")
+  return sparse_to_dense(source, label_value=1., other_value=0.)
 
 
-def smooth_one_hot(source: nn.Tensor, *, label_prob: Union[nn.Tensor, float],
-                   name: Optional[str] = None) -> nn.Tensor:
+def smooth_one_hot(source: nn.Tensor, *, label_prob: Union[nn.Tensor, float]) -> nn.Tensor:
   """
   Smooth variant of :func:`one_hot`.
   Uses ``label_prob`` for the labels and ``(1 - label_prob) / (dim - 1)`` for the remaining values.
@@ -253,8 +252,7 @@ def smooth_one_hot(source: nn.Tensor, *, label_prob: Union[nn.Tensor, float],
   if source.data.sparse_dim.dimension is None:
     raise NotImplementedError(f"smooth_one_hot({source}) not implemented for dynamic dims")
   return sparse_to_dense(
-    source, label_value=label_prob, other_value=(1. - label_prob) / (source.data.sparse_dim.dimension - 1),
-    name=name or "smooth_one_hot")
+    source, label_value=label_prob, other_value=(1. - label_prob) / (source.data.sparse_dim.dimension - 1))
 
 
 def label_smoothing(source: nn.Tensor, smoothing: Union[nn.Tensor, float],

--- a/nn/utils.py
+++ b/nn/utils.py
@@ -71,7 +71,7 @@ def dropout(source: nn.Tensor,
   from .base import make_layer
   return make_layer(
     {"class": "dropout", "from": source, **opts},
-    name=name or "dropout")
+    name=name or "dropout", name_ctx_ignore_top_stack_frames=1)
 
 
 def stop_gradient(source: nn.Tensor, name: Optional[str] = None) -> nn.Tensor:

--- a/tests/test_nn_array.py
+++ b/tests/test_nn_array.py
@@ -16,7 +16,6 @@ else:
 def test_concat():
   class _Net(nn.Module):
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       return nn.concat((x, x.feature_dim), (x * 2., x.feature_dim))
 

--- a/tests/test_nn_attention.py
+++ b/tests/test_nn_attention.py
@@ -24,7 +24,6 @@ def test_self_attention():
         value_dim_total=nn.FeatureDim("value-dim-total", 33),
         num_heads=3)
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """forward"""
       return self.self_att(x, axis=axis)

--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -198,7 +198,6 @@ def test_multiple_returns_depth_1():
   config, net_dict = dummy_config_net_dict(net)
   pprint(net_dict)
   assert net_dict["output"]["from"] == "sub"
-  assert net_dict["sub"]["subnetwork"]["linear"]["subnetwork"]["dot"]["from"][0] == "base:base:data:data"
   dummy_run_net(config)
 
 

--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -72,6 +72,27 @@ def test_simple_net_arithmetic():
   dummy_run_net(config)
 
 
+def _functional_example(x: nn.Tensor) -> nn.Tensor:
+  return nn.tanh((x + 1.) * 0.5)
+
+
+def test_functional_auto_name_ctx():
+  class _Net(nn.Module):
+    def __call__(self, x: nn.Tensor) -> nn.Tensor:
+      x -= 1.
+      x = _functional_example(x)
+      x += 1.
+      x = _functional_example(x)
+      return x
+
+  config, net_dict = dummy_config_net_dict(net=_Net())
+  assert "_functional_example" in net_dict
+  assert_equal(net_dict["_functional_example"]["class"], "subnetwork")
+  assert_equal(net_dict["_functional_example_0"]["class"], "subnetwork")
+  assert "_functional_example_1" not in net_dict
+  dummy_run_net(config)
+
+
 def test_simple_net_share_params():
   class _Net(nn.Module):
     def __init__(self):

--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -92,8 +92,6 @@ def test_simple_net_share_params():
   net = _Net()
   config, net_dict = dummy_config_net_dict(net)
   assert "linear2" in net_dict
-  assert "linear2_0" in net_dict
-  assert_equal(net_dict["linear2_0"]["name_scope"], "linear2")
   dummy_run_net(config, net=net)
 
 

--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -23,7 +23,6 @@ def test_simple_net_linear():
       super().__init__()
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x) -> nn.Tensor:
       """
       Forward
@@ -47,7 +46,6 @@ def test_simple_net_linear_square_matrix():
       self.linear = nn.Linear(out_dim)
       self.linear2 = nn.Linear(out_dim)
 
-    @nn.scoped
     def __call__(self, x) -> nn.Tensor:
       """
       Forward
@@ -63,7 +61,6 @@ def test_simple_net_linear_square_matrix():
 
 def test_simple_net_arithmetic():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x) -> nn.Tensor:
       """
       Forward
@@ -83,7 +80,6 @@ def test_simple_net_share_params():
       self.linear = nn.Linear(self.dim)
       self.linear2 = nn.Linear(self.dim)
 
-    @nn.scoped
     def __call__(self, x) -> nn.Tensor:
       """
       Forward
@@ -109,7 +105,6 @@ def test_explicit_root_ctx_sub():
       self.linear = nn.Linear(out_dim)
       self.dropout = dropout
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """
       forward
@@ -147,7 +142,6 @@ def test_root_mod_call_twice():
       self.linear = nn.Linear(out_dim)
       self.dropout = dropout
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """
       forward
@@ -185,7 +179,6 @@ def test_multiple_returns_depth_1():
       super().__init__()
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -198,7 +191,6 @@ def test_multiple_returns_depth_1():
       super().__init__()
       self.sub = _SubNet()
 
-    @nn.scoped
     def __call__(self, x) -> nn.Tensor:
       """
       Forward
@@ -220,7 +212,6 @@ def test_multiple_returns_depth_2():
       super().__init__()
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -233,7 +224,6 @@ def test_multiple_returns_depth_2():
       super().__init__()
       self.sub = _SubSubNet()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -246,7 +236,6 @@ def test_multiple_returns_depth_2():
       super().__init__()
       self.sub = _SubNet()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """
       Forward
@@ -275,7 +264,6 @@ def test_from_call_variations():
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
       self.linear2 = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -290,7 +278,6 @@ def test_from_call_variations():
       self.sub = _SubNet()
       self.sub2 = _SubNet()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """
       Forward
@@ -317,7 +304,6 @@ def test_from_call_variations2():
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
       self.linear2 = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -332,7 +318,6 @@ def test_from_call_variations2():
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
       self.linear2 = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, y: nn.Tensor) -> Tuple[nn.Tensor, nn.Tensor]:
       """
       Forward
@@ -348,7 +333,6 @@ def test_from_call_variations2():
       self.sub2 = _SubNet2()
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """
       Forward
@@ -459,7 +443,6 @@ def test_parameter_not_initialized():
 
 def test_const_array_serialization():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       import numpy
       c = nn.constant(
@@ -473,7 +456,6 @@ def test_const_array_serialization():
 
 def test_asr_specaug_v1_eval_func_serialization():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       # specaugment_v1 uses a custom eval layer with a ref to a Python function,
       # which is defined in that module.

--- a/tests/test_nn_base.py
+++ b/tests/test_nn_base.py
@@ -167,8 +167,6 @@ def test_root_mod_call_twice():
   pprint(net_dict)
 
   assert "linear" in net_dict
-  assert "test_block_0" in net_dict
-  assert_equal(net_dict["test_block_0"]["name_scope"], "")
 
 
 def test_multiple_returns_depth_1():

--- a/tests/test_nn_cond.py
+++ b/tests/test_nn_cond.py
@@ -22,7 +22,6 @@ def test_cond():
       self.linear_true = nn.Linear(out_dim)
       self.linear_false = nn.Linear(out_dim)
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       with nn.Cond(nn.length(x, axis=nn.batch_dim) % 2 == 0) as cond:
         cond.true = self.linear_true(x)
@@ -41,7 +40,6 @@ def test_cond_shared_params():
       super().__init__()
       self.linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       with nn.Cond(nn.length(x, axis=nn.batch_dim) % 2 == 0) as cond:
         cond.true = self.linear(x)
@@ -69,7 +67,6 @@ def test_cond_twice_shared_params():
       self.linear_true = nn.Linear(out_dim, in_dim=out_dim)
       self.linear_false = nn.Linear(out_dim, in_dim=out_dim)
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       x = self.pre_linear(x)
       with nn.Cond(nn.length(x, axis=nn.batch_dim) % 2 == 0) as cond:
@@ -95,7 +92,6 @@ def test_cond_random():
       super().__init__()
       self.rnd = nn.Random()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       with nn.Cond(nn.length(x, axis=nn.batch_dim) % 2 == 0) as cond:
         cond.true = x + self.rnd.normal(x.shape_ordered)

--- a/tests/test_nn_container.py
+++ b/tests/test_nn_container.py
@@ -22,7 +22,6 @@ def test_module_list():
       self.base_dim = nn.FeatureDim("linear-out", 3)
       self.ls = nn.ModuleList([nn.Linear(self.base_dim + i) for i in range_(4)])
 
-    @nn.scoped
     def __call__(self, out: nn.Tensor) -> nn.Tensor:
       """
       Forward
@@ -52,7 +51,6 @@ def test_sequential_base_case():
         nn.Linear(nn.FeatureDim("feat2", 2)),
         nn.Linear(nn.FeatureDim("feat3", 3)))
 
-    @nn.scoped
     def __call__(self, data: nn.Tensor) -> nn.Tensor:
       """
       Forward
@@ -82,7 +80,6 @@ def test_sequential_named_case():
       x["three"] = nn.Linear(nn.FeatureDim("linear3-out", 3))
       self.seq = nn.Sequential(x)
 
-    @nn.scoped
     def __call__(self, data: nn.Tensor) -> nn.Tensor:
       """
       Forward

--- a/tests/test_nn_conv.py
+++ b/tests/test_nn_conv.py
@@ -21,7 +21,6 @@ def test_conv1d():
       # Use some downsampling + valid padding to test dim tag math.
       self.conv = nn.Conv1d(nn.FeatureDim("out", 13), 4, strides=3, padding="valid")
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward

--- a/tests/test_nn_generated_layers.py
+++ b/tests/test_nn_generated_layers.py
@@ -17,7 +17,6 @@ else:
 def test_range_from_length():
   # https://github.com/rwth-i6/returnn_common/issues/134
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       durations = nn.cast(nn.reduce(x, axis=x.feature_dim, mode="sum"), dtype="int32")
       durations.verify_out_shape({nn.batch_dim, axis})

--- a/tests/test_nn_loop.py
+++ b/tests/test_nn_loop.py
@@ -22,7 +22,6 @@ def test_rec_ff():
       super().__init__()
       self.rec_linear = nn.Linear(nn.FeatureDim("linear-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward
@@ -58,7 +57,6 @@ def test_rec_inner_lstm():
       super().__init__()
       self.lstm = nn.LSTM(nn.FeatureDim("out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward
@@ -82,7 +80,6 @@ def test_rec_inner_lstm():
 
 def test_rec_simple_iter():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward
@@ -107,7 +104,6 @@ def test_rec_hidden():
       super().__init__()
       self.lstm = nn.LSTM(nn.FeatureDim("lstm-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward
@@ -130,7 +126,6 @@ def test_rec_hidden_initial():
       self.linear = nn.Linear(self.out_dim)
       self.lstm = nn.LSTM(self.out_dim)
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward
@@ -148,7 +143,6 @@ def test_rec_hidden_initial():
 
 def test_loop_axis_indices():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       loop = nn.Loop(axis=axis)
       indices = nn.range_in_axis(x, axis=axis)

--- a/tests/test_nn_loss.py
+++ b/tests/test_nn_loss.py
@@ -15,6 +15,7 @@ else:
 
 
 def _make_dummy_model_with_ce_out() -> Tuple[nn.Module, nn.Tensor]:
+  nn.auto_setup_name_ctx_ignore_func(_make_dummy_model_with_ce_out)
   time_dim = nn.SpatialDim("time")
   in_dim = nn.FeatureDim("input", 3)
   out_dim = nn.FeatureDim("out", 5)

--- a/tests/test_nn_loss.py
+++ b/tests/test_nn_loss.py
@@ -46,3 +46,20 @@ def test_mark_as_loss():
   config_code = nn.get_returnn_config().get_complete_py_code_str(mod)
   config, net_dict = config_net_dict_via_serialized(config_code)
   dummy_run_net(config, train=True)
+
+
+def _functional_mark_as_loss(x: nn.Tensor):
+  x *= 2.
+  x = nn.minimum(x, 10.)
+  x.mark_as_loss()
+
+
+def test_mark_as_loss_in_subnet():
+  nn.reset_default_root_name_ctx()
+  mod, loss = _make_dummy_model_with_ce_out()
+  _functional_mark_as_loss(loss)
+
+  config_code = nn.get_returnn_config().get_complete_py_code_str(mod)
+  config, net_dict = config_net_dict_via_serialized(config_code)
+  assert net_dict["_functional_mark_as_loss"]["class"] == "subnetwork"
+  dummy_run_net(config, train=True)

--- a/tests/test_nn_masked_computation.py
+++ b/tests/test_nn_masked_computation.py
@@ -21,7 +21,6 @@ def test_masked_computation_lstm():
       super().__init__()
       self.lstm = nn.LSTM(nn.FeatureDim("out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward

--- a/tests/test_nn_math.py
+++ b/tests/test_nn_math.py
@@ -35,7 +35,6 @@ def test_op_broadcasting():
 
 def test_split_glu():
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """forward"""
       a, b = nn.split(x, axis=axis, out_dims=[axis // 2, axis // 2])
@@ -87,7 +86,6 @@ def test_split_glu():
 def test_cumcum():
   # https://github.com/rwth-i6/returnn_common/issues/133
   class _Net(nn.Module):
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward

--- a/tests/test_nn_normalization.py
+++ b/tests/test_nn_normalization.py
@@ -20,7 +20,6 @@ def test_batch_norm():
       super().__init__()
       self.bn = nn.BatchNorm(use_mask=False)
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       """forward"""
       return self.bn(x)

--- a/tests/test_nn_rand.py
+++ b/tests/test_nn_rand.py
@@ -22,7 +22,6 @@ def test_random_normal():
       super().__init__()
       self.rnd = nn.Random()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       return x + self.rnd.normal(x.shape_ordered)
 
@@ -43,7 +42,6 @@ def test_random_multi_call():
       super().__init__()
       self.rnd = nn.Random()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor) -> nn.Tensor:
       return x + self.rnd.normal(x.shape_ordered) - self.rnd.normal(x.shape_ordered)
 

--- a/tests/test_nn_rand.py
+++ b/tests/test_nn_rand.py
@@ -60,7 +60,6 @@ def test_random_in_loop():
       super().__init__()
       self.rnd = nn.Random()
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       loop = nn.Loop(axis=axis)
       with loop:

--- a/tests/test_nn_rec.py
+++ b/tests/test_nn_rec.py
@@ -21,7 +21,6 @@ def test_simple_net_lstm():
       super().__init__()
       self.lstm = nn.LSTM(nn.FeatureDim("lstm-out", 13))
 
-    @nn.scoped
     def __call__(self, x: nn.Tensor, *, axis: nn.Dim) -> nn.Tensor:
       """
       Forward


### PR DESCRIPTION
Fix #159.

Removes `scoped`.

Also cleans up some related code.

In `NameCtx.current_ctx`, we will derive the scope.
