### PR TITLE
Fix Scale Init Normalize

### DIFF
--- a/nn/normalization.py
+++ b/nn/normalization.py
@@ -205,7 +205,9 @@ class Normalize(nn.Module):
     self.epsilon = epsilon
     if isinstance(param_shape, nn.Dim):
       param_shape = [param_shape]
-    self.scale = nn.Parameter(shape=param_shape) if scale else None
+    if scale is not None:
+      self.scale = nn.Parameter(shape=param_shape)
+      self.scale.initial = 1.0
     self.bias = nn.Parameter(shape=param_shape) if bias else None
 
   def __call__(self, a: nn.Tensor, *, axis: Union[nn.Dim, Sequence[nn.Dim]]):

--- a/nn/normalization.py
+++ b/nn/normalization.py
@@ -205,7 +205,8 @@ class Normalize(nn.Module):
     self.epsilon = epsilon
     if isinstance(param_shape, nn.Dim):
       param_shape = [param_shape]
-    if scale is not None:
+    self.scale = None
+    if scale:
       self.scale = nn.Parameter(shape=param_shape)
       self.scale.initial = 1.0
     self.bias = nn.Parameter(shape=param_shape) if bias else None


### PR DESCRIPTION
Scale parameter of `nn.Normalize` was initialized with 0 instead of (as in returnn) with 1.